### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ let result = kilograms.add(pounds)
 println(result)
 ```
 
-For Cocoapods Integration with Swift please refer to the my blog post [Integrating Cocoapods with a Swift project][blog].
+For CocoaPods Integration with Swift please refer to the my blog post [Integrating CocoaPods with a Swift project][blog].
 
 [blog]:http://michal.codes/integrating-cocoapods-with-a-swift-project/
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
