### PR TITLE
Added: US Short Ton

### DIFF
--- a/Source/Units/Mass/MKMassUnit+Imperial.h
+++ b/Source/Units/Mass/MKMassUnit+Imperial.h
@@ -35,6 +35,7 @@
 + (instancetype)quarter;
 + (instancetype)hundredweight;
 + (instancetype)ton;
++ (instancetype)shortton;
 
 @end
 
@@ -48,6 +49,7 @@
 + (instancetype)mass_quarterWithAmount:(NSNumber *)amount;
 + (instancetype)mass_hundredweightWithAmount:(NSNumber *)amount;
 + (instancetype)mass_tonWithAmount:(NSNumber *)amount;
++ (instancetype)mass_shorttonWithAmount:(NSNumber *)amount;
 
 @end
 
@@ -61,5 +63,6 @@
 - (MKQuantity *)mass_quarter;
 - (MKQuantity *)mass_hundredweight;
 - (MKQuantity *)mass_ton;
+- (MKQuantity *)mass_shortton;
 
 @end

--- a/Source/Units/Mass/MKMassUnit+Imperial.m
+++ b/Source/Units/Mass/MKMassUnit+Imperial.m
@@ -122,6 +122,18 @@
                       withRatio:ratio];
 }
 
++ (instancetype)shortton {
+    static NSString *name   = @"shortton";
+    static NSString *symbol = @"tn";
+    id ratio = [NSDecimalNumber decimalNumberWithMantissa:90718475 exponent:-5 isNegative:NO];
+    
+//     907.18475 kg
+    
+    return [self createWithName:name
+                     withSymbol:symbol
+                      withRatio:ratio];
+}
+
 
 @end
 


### PR DESCRIPTION
Added the US Short Ton to MKMassUnit+Imperial. The symbol is
technically “t”, but that’s being used by Metric Ton, so I set it to
“tn” to avoid confusion. I also considered “ust”, “USt”, and “ton”. If
anyone has a better symbol for it, please change it.