### PR TITLE
Add ByteUnit for digital storage conversions

### DIFF
--- a/Sources/MKUnits/ByteUnit.swift
+++ b/Sources/MKUnits/ByteUnit.swift
@@ -1,0 +1,127 @@
+//
+//  ByteUnit.swift
+//  MKUnits
+//
+//  Copyright (c) 2016 Michal Konturek <michal.konturek@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public final class ByteUnit: Unit, @unchecked Sendable {
+
+  /// Returns petabyte `[PB]` byte unit.
+  public static let petabyte = ByteUnit(
+    name: "petabyte",
+    symbol: "PB",
+    ratio: 1_125_899_906_842_624
+  )
+
+  /// Returns terabyte `[TB]` byte unit.
+  public static let terabyte = ByteUnit(
+    name: "terabyte",
+    symbol: "TB",
+    ratio: 1_099_511_627_776
+  )
+
+  /// Returns gigabyte `[GB]` byte unit.
+  public static let gigabyte = ByteUnit(
+    name: "gigabyte",
+    symbol: "GB",
+    ratio: 1_073_741_824
+  )
+
+  /// Returns megabyte `[MB]` byte unit.
+  public static let megabyte = ByteUnit(
+    name: "megabyte",
+    symbol: "MB",
+    ratio: 1_048_576
+  )
+
+  /// Returns kilobyte `[KB]` byte unit.
+  public static let kilobyte = ByteUnit(
+    name: "kilobyte",
+    symbol: "KB",
+    ratio: 1_024
+  )
+
+  /// Returns byte `[B]` byte unit.
+  ///
+  /// This is a base unit.
+  public static let byte = ByteUnit(
+    name: "byte",
+    symbol: "B",
+    ratio: 1
+  )
+}
+
+extension Int {
+  /// Returns instance converted as petabyte quantity.
+  public func petabyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.petabyte)
+  }
+  /// Returns instance converted as terabyte quantity.
+  public func terabyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.terabyte)
+  }
+  /// Returns instance converted as gigabyte quantity.
+  public func gigabyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.gigabyte)
+  }
+  /// Returns instance converted as megabyte quantity.
+  public func megabyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.megabyte)
+  }
+  /// Returns instance converted as kilobyte quantity.
+  public func kilobyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.kilobyte)
+  }
+  /// Returns instance converted as byte quantity.
+  public func byte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.byte)
+  }
+}
+
+extension Double {
+  /// Returns instance converted as petabyte quantity.
+  public func petabyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.petabyte)
+  }
+  /// Returns instance converted as terabyte quantity.
+  public func terabyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.terabyte)
+  }
+  /// Returns instance converted as gigabyte quantity.
+  public func gigabyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.gigabyte)
+  }
+  /// Returns instance converted as megabyte quantity.
+  public func megabyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.megabyte)
+  }
+  /// Returns instance converted as kilobyte quantity.
+  public func kilobyte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.kilobyte)
+  }
+  /// Returns instance converted as byte quantity.
+  public func byte() -> Quantity {
+    Quantity(amount: Decimal(self), unit: ByteUnit.byte)
+  }
+}

--- a/Tests/MKUnitsTests/ByteUnitTests.swift
+++ b/Tests/MKUnitsTests/ByteUnitTests.swift
@@ -1,0 +1,61 @@
+//
+//  ByteUnitTests.swift
+//  MKUnits
+//
+//  Copyright (c) 2016 Michal Konturek <michal.konturek@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import MKUnits
+import Testing
+
+@Suite struct ByteUnitTests {
+
+  @Test func correctness() {
+    #expect(1.petabyte() == 1024.terabyte())
+    #expect(1.terabyte() == 1024.gigabyte())
+    #expect(1.gigabyte() == 1024.megabyte())
+    #expect(1.megabyte() == 1024.kilobyte())
+    #expect(1.kilobyte() == 1024.byte())
+
+    #expect(
+      1.gigabyte().converted(ByteUnit.byte)
+        == Quantity(amount: 1_073_741_824, unit: ByteUnit.byte))
+
+    #expect(
+      2048.kilobyte().converted(ByteUnit.megabyte)
+        == Quantity(amount: 2, unit: ByteUnit.megabyte))
+  }
+
+  @Test func fluentAPI() {
+    self.assert(1.petabyte(), expectedAmount: 1, expectedUnit: ByteUnit.petabyte)
+    self.assert(1.5.terabyte(), expectedAmount: 1.5, expectedUnit: ByteUnit.terabyte)
+    self.assert(1.gigabyte(), expectedAmount: 1, expectedUnit: ByteUnit.gigabyte)
+    self.assert(1.5.megabyte(), expectedAmount: 1.5, expectedUnit: ByteUnit.megabyte)
+    self.assert(1.kilobyte(), expectedAmount: 1, expectedUnit: ByteUnit.kilobyte)
+    self.assert(1.byte(), expectedAmount: 1, expectedUnit: ByteUnit.byte)
+  }
+
+  private func assert(_ item: Quantity, expectedAmount: Decimal, expectedUnit: MKUnits.Unit) {
+    #expect(item.amount == expectedAmount)
+    #expect(item.unit == expectedUnit)
+  }
+}

--- a/openspec/changes/archive/2026-03-07-add-byte-unit/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-07-add-byte-unit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-07

--- a/openspec/changes/archive/2026-03-07-add-byte-unit/design.md
+++ b/openspec/changes/archive/2026-03-07-add-byte-unit/design.md
@@ -1,0 +1,33 @@
+## Context
+
+MKUnits defines unit groups as `final class` subclasses of `Unit` with `public static let` constants for each unit. Conversion uses a `ratio` (`Decimal`) relative to a base unit. Each unit group also provides `Int` and `Double` fluent API extensions. The new `ByteUnit` follows this established pattern exactly.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a `ByteUnit` group with binary-prefixed units (byte through petabyte, base-1024)
+- Provide fluent API extensions matching existing conventions
+- Full test coverage for conversions and fluent API
+
+**Non-Goals:**
+- SI/decimal prefixes (kibibyte, mebibyte, etc.) — can be added later
+- Bit-level units (bit, kilobit) — out of scope for this change
+
+## Decisions
+
+### Decision 1: Use base-1024 (binary) ratios
+
+The units use traditional binary prefixes: 1 KB = 1024 bytes, 1 MB = 1024 KB, etc. This matches common developer expectations. SI prefixes (KiB, MiB) are intentionally excluded to keep the initial scope small.
+
+### Decision 2: Byte as the base unit (ratio = 1)
+
+Byte has ratio `1`, with larger units having integer power-of-1024 ratios (1024, 1048576, etc.). All ratios are exact integers, so no `Decimal(string:)` is needed.
+
+### Decision 3: Units included
+
+byte, kilobyte, megabyte, gigabyte, terabyte, petabyte — six units covering the most common range.
+
+## Risks / Trade-offs
+
+- **Naming ambiguity** (KB vs KiB) → Documented as binary (base-1024). SI prefixes can be added as a separate change if needed.
+- **No fractional ratios** → All ratios are exact integers, so no precision concerns.

--- a/openspec/changes/archive/2026-03-07-add-byte-unit/proposal.md
+++ b/openspec/changes/archive/2026-03-07-add-byte-unit/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+MKUnits covers physical quantities (mass, length, area, time, volume, energy) but lacks support for digital storage units. Bytes, kilobytes, megabytes, etc. are among the most commonly converted units in software development contexts.
+
+## What Changes
+
+- Add a new `ByteUnit` unit group with binary-prefixed units (byte, kilobyte, megabyte, gigabyte, terabyte, petabyte) using base-1024 ratios
+- Add `Int` and `Double` fluent API extensions for all byte units
+- Add unit tests for correctness and fluent API
+
+## Capabilities
+
+### New Capabilities
+- `byte-unit`: Digital storage unit group with base-1024 conversions and fluent API extensions
+
+### Modified Capabilities
+<!-- None — this is a purely additive change -->
+
+## Impact
+
+- New source file: `Sources/MKUnits/ByteUnit.swift`
+- New test file: `Tests/MKUnitsTests/ByteUnitTests.swift`
+- No changes to existing code or APIs

--- a/openspec/changes/archive/2026-03-07-add-byte-unit/specs/byte-unit/spec.md
+++ b/openspec/changes/archive/2026-03-07-add-byte-unit/specs/byte-unit/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: ByteUnit defines digital storage units
+
+The system SHALL provide a `ByteUnit` class (final subclass of `Unit`, `@unchecked Sendable`) with `public static let` constants for: byte, kilobyte, megabyte, gigabyte, terabyte, and petabyte. The byte SHALL be the base unit (ratio 1). Each successive unit SHALL have a ratio of 1024 times the previous unit.
+
+#### Scenario: Unit ratios are correct
+
+- **WHEN** a `ByteUnit` constant is accessed
+- **THEN** its ratio SHALL be: byte=1, kilobyte=1024, megabyte=1048576, gigabyte=1073741824, terabyte=1099511627776, petabyte=1125899906842624
+
+#### Scenario: Units have correct symbols
+
+- **WHEN** a `ByteUnit` constant is accessed
+- **THEN** its symbol SHALL be: byte="B", kilobyte="KB", megabyte="MB", gigabyte="GB", terabyte="TB", petabyte="PB"
+
+### Requirement: ByteUnit supports cross-unit conversion
+
+Quantities using `ByteUnit` SHALL be convertible to any other `ByteUnit` using the standard `Quantity.converted()` method.
+
+#### Scenario: Convert megabytes to kilobytes
+
+- **WHEN** 1 megabyte is converted to kilobytes
+- **THEN** the result SHALL be 1024 kilobytes
+
+#### Scenario: Convert gigabytes to bytes
+
+- **WHEN** 1 gigabyte is converted to bytes
+- **THEN** the result SHALL be 1073741824 bytes
+
+#### Scenario: Convert kilobytes to megabytes
+
+- **WHEN** 2048 kilobytes is converted to megabytes
+- **THEN** the result SHALL be 2 megabytes
+
+### Requirement: ByteUnit provides Int fluent API
+
+The system SHALL extend `Int` with methods for each byte unit that return a `Quantity` with the corresponding `ByteUnit`.
+
+#### Scenario: Int fluent API creates correct quantities
+
+- **WHEN** `5.megabyte()` is called on an `Int`
+- **THEN** the result SHALL be a `Quantity` with amount `5` and unit `ByteUnit.megabyte`
+
+### Requirement: ByteUnit provides Double fluent API
+
+The system SHALL extend `Double` with methods for each byte unit that return a `Quantity` with the corresponding `ByteUnit`.
+
+#### Scenario: Double fluent API creates correct quantities
+
+- **WHEN** `1.5.gigabyte()` is called on a `Double`
+- **THEN** the result SHALL be a `Quantity` with amount `1.5` and unit `ByteUnit.gigabyte`

--- a/openspec/changes/archive/2026-03-07-add-byte-unit/tasks.md
+++ b/openspec/changes/archive/2026-03-07-add-byte-unit/tasks.md
@@ -1,0 +1,16 @@
+## 1. ByteUnit Source
+
+- [x] 1.1 Create `Sources/MKUnits/ByteUnit.swift` with `ByteUnit` class and six unit constants (byte, kilobyte, megabyte, gigabyte, terabyte, petabyte) using base-1024 ratios
+- [x] 1.2 Add `Int` fluent API extensions for all six byte units
+- [x] 1.3 Add `Double` fluent API extensions for all six byte units
+
+## 2. Tests
+
+- [x] 2.1 Create `Tests/MKUnitsTests/ByteUnitTests.swift` with `correctness()` test for cross-unit conversions
+- [x] 2.2 Add `fluentAPI()` test for `Int` and `Double` extension methods
+
+## 3. Verify
+
+- [x] 3.1 Run `swift build` to confirm compilation
+- [x] 3.2 Run `swift test --filter ByteUnitTests` to confirm all tests pass (skipped — `Testing` module unavailable with CLT-only toolchain; CI will verify)
+- [x] 3.3 Run `xcrun swift-format lint --strict --recursive Sources/ Tests/` to confirm formatting

--- a/openspec/specs/byte-unit/spec.md
+++ b/openspec/specs/byte-unit/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: ByteUnit defines digital storage units
+
+The system SHALL provide a `ByteUnit` class (final subclass of `Unit`, `@unchecked Sendable`) with `public static let` constants for: byte, kilobyte, megabyte, gigabyte, terabyte, and petabyte. The byte SHALL be the base unit (ratio 1). Each successive unit SHALL have a ratio of 1024 times the previous unit.
+
+#### Scenario: Unit ratios are correct
+
+- **WHEN** a `ByteUnit` constant is accessed
+- **THEN** its ratio SHALL be: byte=1, kilobyte=1024, megabyte=1048576, gigabyte=1073741824, terabyte=1099511627776, petabyte=1125899906842624
+
+#### Scenario: Units have correct symbols
+
+- **WHEN** a `ByteUnit` constant is accessed
+- **THEN** its symbol SHALL be: byte="B", kilobyte="KB", megabyte="MB", gigabyte="GB", terabyte="TB", petabyte="PB"
+
+### Requirement: ByteUnit supports cross-unit conversion
+
+Quantities using `ByteUnit` SHALL be convertible to any other `ByteUnit` using the standard `Quantity.converted()` method.
+
+#### Scenario: Convert megabytes to kilobytes
+
+- **WHEN** 1 megabyte is converted to kilobytes
+- **THEN** the result SHALL be 1024 kilobytes
+
+#### Scenario: Convert gigabytes to bytes
+
+- **WHEN** 1 gigabyte is converted to bytes
+- **THEN** the result SHALL be 1073741824 bytes
+
+#### Scenario: Convert kilobytes to megabytes
+
+- **WHEN** 2048 kilobytes is converted to megabytes
+- **THEN** the result SHALL be 2 megabytes
+
+### Requirement: ByteUnit provides Int fluent API
+
+The system SHALL extend `Int` with methods for each byte unit that return a `Quantity` with the corresponding `ByteUnit`.
+
+#### Scenario: Int fluent API creates correct quantities
+
+- **WHEN** `5.megabyte()` is called on an `Int`
+- **THEN** the result SHALL be a `Quantity` with amount `5` and unit `ByteUnit.megabyte`
+
+### Requirement: ByteUnit provides Double fluent API
+
+The system SHALL extend `Double` with methods for each byte unit that return a `Quantity` with the corresponding `ByteUnit`.
+
+#### Scenario: Double fluent API creates correct quantities
+
+- **WHEN** `1.5.gigabyte()` is called on a `Double`
+- **THEN** the result SHALL be a `Quantity` with amount `1.5` and unit `ByteUnit.gigabyte`


### PR DESCRIPTION
## Summary

- Add `ByteUnit` unit group with base-1024 binary units: byte, kilobyte, megabyte, gigabyte, terabyte, petabyte
- Add `Int` and `Double` fluent API extensions (e.g., `5.megabyte()`, `1.5.gigabyte()`)
- Add `ByteUnitTests` with conversion correctness and fluent API tests
- Include archived OpenSpec change artifacts and synced specs

## Test plan

- [ ] `swift build` compiles successfully
- [ ] `swift test --filter ByteUnitTests` passes (correctness + fluent API)
- [ ] `swift-format lint --strict` passes on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)